### PR TITLE
Add `yarn validate` for JSON testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,6 @@ $ yarn install
 $ yarn test
 ```
 
-By default the Web Annotation JSON-related tests will skipped. To use those
-with a specific local file you can use the `--url` parameter plus a local file
-path.
-
-```sh
-$ yarn test --url ../anno1.json
-```
-
 ##### Run localhost demo server
 
 ```sh
@@ -62,6 +54,18 @@ $ yarn start
 
 Once the test server has started, you can browse a local demo, and run tests in
 a browser by visiting `http://localhost:8080/`.
+
+
+## Web Annotation Data Model Validation
+
+If you have any Web Annotation Data Model JSON documents, you can validate them
+using the `validate` script:
+
+
+```sh
+$ yarn validate --url ../anno1.json
+```
+
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint": "eslint . --ext js,mjs --fix --quiet",
     "prepare": "lerna run prepare",
     "start": "webpack-serve",
-    "test": "cross-env BABEL_ENV=test nyc mocha -r esm"
+    "test": "cross-env BABEL_ENV=test nyc mocha -r esm packages/*/test/**/*.mjs",
+    "validate": "cross-env BABEL_ENV=test nyc mocha -r esm test/**/*.mjs"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.42",

--- a/test/data-model.mjs
+++ b/test/data-model.mjs
@@ -37,7 +37,7 @@ const musts = JSON.parse(
   )
 );
 
-describe('Test schemas', () => {
+describe('Test JSON against Schemas', () => {
   let data = '';
 
   before(function() {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -3,5 +3,3 @@
 -r chai/register-assert
 --recursive
 --watch-extensions mjs
-packages/*/test/**/*.mjs
-test/**/*.mjs


### PR DESCRIPTION
Reduces the `yarn test` (run by travis, pre-commit, etc) to just code testing.

Introduces `yarn validate --url ../anno1.json` in place of the current `yarn test --url ../anno1.json`. This also means that code coverage is more accurate because `yarn test` only tests things in `packages/`.