### PR TITLE
Change issue tracker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > and humans.
 
 * [`dev@` Mailing List archive](http://mail-archives.apache.org/mod_mbox/incubator-annotator-dev/)
-* [Issue Tracker](https://issues.apache.org/jira/browse/ANNO)
+* [Issue Tracker](https://github.com/apache/incubator-annotator/issues)
 * [Wiki](https://cwiki.apache.org/confluence/display/ANNO)
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 * [`dev@` Mailing List archive](http://mail-archives.apache.org/mod_mbox/incubator-annotator-dev/)
 * [Issue Tracker](https://github.com/apache/incubator-annotator/issues)
-* [Wiki](https://cwiki.apache.org/confluence/display/ANNO)
+* [Wiki](https://github.com/apache/incubator-annotator)
 
 ## Usage
 


### PR DESCRIPTION
Seems like the actual work of tracking issues is going on in Github?