### PR TITLE
Use highlighter in demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -33,7 +33,6 @@ under the License.
     }
     mark {
       background-color: rgba(255, 255, 0, 0.5);
-      outline: 0.1px solid rgba(255, 100, 0, 0.8);
     }
     #parsed {
       height: 15rem;

--- a/demo/index.html
+++ b/demo/index.html
@@ -33,6 +33,7 @@ under the License.
     }
     mark {
       background-color: rgba(255, 255, 0, 0.5);
+      outline: 0.1px solid rgba(255, 100, 0, 0.8);
     }
     #parsed {
       height: 15rem;

--- a/demo/index.js
+++ b/demo/index.js
@@ -32,8 +32,13 @@ import {
 } from '@annotator/dom';
 import { makeRefinable } from '@annotator/selector';
 
-function clear() {
-  corpus.innerHTML = selectable.innerHTML;
+const cleanupFunctions = [];
+
+function cleanup() {
+  let removeHighlight;
+  while (removeHighlight = cleanupFunctions.shift()) {
+    removeHighlight();
+  }
 }
 
 const createSelector = makeRefinable(selector => {
@@ -50,7 +55,7 @@ const createSelector = makeRefinable(selector => {
 });
 
 const refresh = async () => {
-  clear();
+  cleanup();
 
   const fragment = window.location.hash.slice(1);
   if (!fragment) return;
@@ -64,7 +69,8 @@ const refresh = async () => {
   }
 
   for (const range of ranges) {
-    highlightRange(range);
+    const removeHighlight = highlightRange(range);
+    cleanupFunctions.push(removeHighlight);
   }
 
   parsed.innerText = JSON.stringify(selector, null, 2);

--- a/demo/index.js
+++ b/demo/index.js
@@ -28,62 +28,12 @@ import {
   createRangeSelectorCreator,
   createTextQuoteSelector,
   describeTextQuote,
+  highlightRange,
 } from '@annotator/dom';
 import { makeRefinable } from '@annotator/selector';
 
 function clear() {
   corpus.innerHTML = selectable.innerHTML;
-}
-
-function highlight(range) {
-  for (const node of textNodes(range)) {
-    const mark = document.createElement('mark');
-    const markRange = document.createRange();
-    markRange.selectNode(node);
-    markRange.surroundContents(mark);
-  }
-}
-
-function textNodes(range) {
-  const nodes = [];
-
-  if (range.collapsed) return nodes;
-
-  let startNode = range.startContainer;
-  let startOffset = range.startOffset;
-
-  if (startNode.nodeType === 3) {
-    if (startOffset > 0 && startOffset < startNode.length) {
-      startNode = startNode.splitText(startOffset);
-      startOffset = 0;
-    }
-  }
-
-  let endNode = range.endContainer;
-  let endOffset = range.endOffset;
-
-  if (endNode.nodeType === 3) {
-    if (endOffset > 0 && endOffset < endNode.length) {
-      endNode = endNode.splitText(endOffset);
-      endOffset = 0;
-    }
-  }
-
-  const walker = document.createTreeWalker(document.documentElement);
-  walker.currentNode = startNode;
-
-  while (walker.currentNode !== endNode) {
-    if (walker.currentNode.nodeType === 3) {
-      nodes.push(walker.currentNode);
-    }
-    walker.nextNode();
-  }
-
-  if (endNode.nodeType === 3 && endOffset > 0) {
-    nodes.push(endNode);
-  }
-
-  return nodes;
 }
 
 const createSelector = makeRefinable(selector => {
@@ -114,7 +64,7 @@ const refresh = async () => {
   }
 
   for (const range of ranges) {
-    highlight(range);
+    highlightRange(range);
   }
 
   parsed.innerText = JSON.stringify(selector, null, 2);

--- a/demo/index.js
+++ b/demo/index.js
@@ -39,6 +39,7 @@ function cleanup() {
   while (removeHighlight = cleanupFunctions.shift()) {
     removeHighlight();
   }
+  corpus.normalize();
 }
 
 const createSelector = makeRefinable(selector => {


### PR DESCRIPTION
Use `highlightRange` from the dom package in the demo instead of the custom implementation.

Also use its `removeHighlight` callbacks instead of just replacing the element’s innerHTML to clean up the highlights.

Note that text nodes that are split by the highlighter will remain split after a `cleanup()`. This reveals a bug in our matching functions, as the “any deeper nesting” example now fails to find any matches (except at a first try, when the text nodes are not yet split).