### PR TITLE
Improve licensing

### DIFF
--- a/.ratignore
+++ b/.ratignore
@@ -8,7 +8,7 @@
 .nycrc
 .ratignore
 .travis.yml
-fragment.pegjs
+fragment.js
 lerna.json
 node_modules
 package.json

--- a/LICENSE
+++ b/LICENSE
@@ -200,3 +200,48 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+---
+
+
+For the packages/fragment-identifier/src/fragment.js and
+packages/fragment-identifier/src/fragment.pegjs components from
+https://github.com/w3c/web-annotation/:
+
+License
+
+By obtaining and/or copying this work, you (the licensee) agree that you have
+read, understood, and will comply with the following terms and conditions.
+
+Permission to copy, modify, and distribute this work, with or without
+modification, for any purpose and without fee or royalty is hereby granted,
+provided that you include the following on ALL copies of the work or portions
+thereof, including modifications:
+
+  * The full text of this NOTICE in a location viewable to users of the
+    redistributed or derivative work.
+
+  * Any pre-existing intellectual property disclaimers, notices, or terms and
+    conditions. If none exist, the W3C Software and Document Short Notice
+    should be included.
+
+  * Notice of any changes or modifications, through a copyright statement on
+    the new code or document such as "This software or document includes
+    material copied from or derived from [title and URI of the W3C document].
+    Copyright © [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
+
+Disclaimers
+
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR
+WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF
+MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE
+SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
+TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+The name and trademarks of copyright holders may NOT be used in advertising or
+publicity pertaining to the work without specific, written prior permission.
+Title to copyright in this work will at all times remain with copyright holders.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ $ yarn start
 Once the test server has started, you can browse a local demo, and run tests in
 a browser by visiting `http://localhost:8080/`.
 
+##### Validate Licensing
+
+[Apache Rat (Release Audit Tool)](https://creadur.apache.org/rat/) is a
+preferred code license checking tool used by [the ASF](https://apache.org/).
+The included `.ratignore` file contains a list of files to exclude from scans.
+
+To check for included licenses, run the following and view the output report:
+```sh
+java -jar ~/bin/apache-rat-0.13/apache-rat-0.13.jar -E .ratignore -d . > rat_report.txt
+```
+
 ## Selectors
 
 Many Annotations refer to part of a resource, rather than all of it, as the Target. We call that part of the resource a Segment (of Interest). A Selector is used to describe how to determine the Segment from within the Source resource.

--- a/packages/fragment-identifier/src/fragment.pegjs
+++ b/packages/fragment-identifier/src/fragment.pegjs
@@ -1,3 +1,6 @@
+// @license: W3C Software and Document Notice and License, https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+// @author: Ivan Herman
+
 {
     function collect() {
       var ret = {};


### PR DESCRIPTION
Fix #63 

This *should* be what's needed to properly record the licensing on the `fragement.pegjs` and the generated (and potentially bundled?) `fragment.js` file.

Actions:
 - added [W3C Software and and Document License](https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document) text to LICENSE and called out the above files (which this license covers)
 - left the related notice content in NOTICE (per the W3C's license...and just for added clarity)
 - added [the license and author declaration comments from the original generated `fragment.js`](https://github.com/w3c/web-annotation/blob/gh-pages/selector-note/converter/fragment.js#L1-L2) to our copy of `fragment.pegjs` (which is the source file)

Apache Rat still complains that this W3C license is not yet approved...

> Files with unapproved licenses:
>      ./packages/dom/src/highlight-range.js
>      ./packages/fragment-identifier/src/fragment.pegjs

Help wanted. 😁 