### PR TITLE
Tweak demo style & text

### DIFF
--- a/web/demo/index.html
+++ b/web/demo/index.html
@@ -18,43 +18,86 @@ under the License.
 -->
 <!doctype html>
 <html>
+<head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Apache Annotator (incubating) demo</title>
-  <link rel="stylesheet" href="https://unpkg.com/awsm.css/dist/awsm.min.css">
+  <link rel="stylesheet" href="../style.css"/>
   <style>
-    blockquote {
-      font-style: italic;
-    }
     a[href^="#selector"]:before {
-      content: '📌';
-      font-size: 75%;
+      content: '📌 ';
     }
-    mark {
-      background-color: rgba(255, 255, 0, 0.5);
-      outline: 0.1px solid rgba(255, 100, 0, 0.8);
+
+    #selectable, #corpus {
+      padding: 1em;
+      border: 1px solid lightgrey;
+      background: white;
     }
+
     #parsed {
-      height: 15rem;
+      height: 15em;
       overflow: scroll;
+      background: white;
+      color: #666666;
+      resize: vertical;
+    }
+
+    .columns {
+      background: aliceblue;
     }
   </style>
+  <script defer src="index.js"></script>
+</head>
+<body>
+  <header>
+    <h1>Apache Annotator <small>(incubating)</small></h1>
+  </header>
+  <nav>
+    <a href="../">← Back</a>
+  </nav>
   <main>
     <h1>Selector Demonstration</h1>
-    <p>This page demonstrates
-      <a
-        href="https://www.w3.org/TR/2017/REC-annotation-model-20170223/#selectors"
-        target="_blank">Selectors</a>.
-      <h2>Fragments</h2>
-    <p>Linking to this page with a selector fragment causes the matching text to
-      be highlighted in the following paragraphs:
-    <blockquote id="corpus">
-      <p>Hello, annotated world!
-      <p>To annotate, or not to annotate, that is the question.
-    </blockquote>
-    <p>Try some examples:
+
+    <p>
+      This page demonstrates Web Annotation
+      <a href="https://www.w3.org/TR/2017/REC-annotation-model-20170223/#selectors" target="_blank">Selectors</a>,
+      standardised JSON objects that describe a selection inside a document with sufficient information to find it back.
+     </p>
+
+    <div class="columns full-width">
+      <div class="column">
+        <h2>Select text here</h2>
+        <p id="selectable">Hello, annotated world! To annotate, or not to annotate, that is the question.</p>
+        <p>
+          Try selecting some text in this paragraph above.
+          Upon a change of selection, a
+          <a rel="external" href="https://www.w3.org/TR/2017/REC-annotation-model-20170223/#text-quote-selector" target="_blank">TextQuoteSelector</a>
+          will be created, that describes what was selected.
+        </p>
+      </div>
+      <div class="column">
+        <h2>Text is found here</h2>
+        <p id="corpus" contenteditable>Hello, annotated world! To annotate, or not to annotate, that is the question.</p>
+        <p>
+          The selector is ‘anchored’ here: the segment it describes is found and highlighted.
+        </p>
+      </div>
+      <div class="column" style="min-width: 20em;">
+        <h2>The selector as JSON:</h2>
+        <pre id="parsed"></pre>
+      </div>
+    </div>
+    <p>
+      Note that the selector is also serialised and shown in the window location, as the fragment identifier
+      (following <a rel="external" href="https://www.w3.org/TR/2017/NOTE-selectors-states-20170223/#frags" target="_blank">this specification</a>).
+      In fact, it is this fragment identifier that is parsed back into JSON and then anchored in the text above.
+    </p>
+    <p>
+      Here are other selectors you can anchor in the text above:
+    </p>
     <ul>
+      <li><a href="#selector(type=TextQuoteSelector,exact=not)">An ambiguous selector (i.e. with multiple matches)</a>
       <li>
         <a href="#selector(type=RangeSelector,startSelector=selector(type=TextQuoteSelector,exact=ann),endSelector=selector(type=TextQuoteSelector,exact=!))">RangeSelector</a>
         (<a href="https://www.w3.org/TR/2017/REC-annotation-model-20170223/#range-selector" target="_blank">spec</a>)
@@ -62,22 +105,8 @@ under the License.
         <a href="#selector(type=TextQuoteSelector,exact=annotated%20world,refinedBy=selector(type=TextQuoteSelector,exact=tat))">Refining
           a selector using another selector</a>
         (<a href="https://www.w3.org/TR/2017/REC-annotation-model-20170223/#refinement-of-selection" target="blank">spec</a>)
-      <li><a href="#selector(type=TextQuoteSelector,exact=not)">Multiple matches</a> (but overlapping matches currently mess up the highlighter)
       <li><a href="#selector(type=TextQuoteSelector,exact=To%20annotate%2C%20or%20not%20to%20annotate%2C,refinedBy=selector(type=RangeSelector,startSelector=selector(type=TextQuoteSelector,exact=To%20annotate,refinedBy=selector(type=TextQuoteSelector,exact=annotate)),endSelector=selector(type=TextQuoteSelector,exact=not%20to%20annotate,refinedBy=selector(type=TextQuoteSelector,exact=%20to)),refinedBy=selector(type=TextQuoteSelector,exact=o)))">Any deeper nesting of the above</a>
     </ul>
-    <p>Below, the same paragraphs are presented again. Selecting some of the text
-      creates a
-      <a
-        href="https://www.w3.org/TR/2017/REC-annotation-model-20170223/#text-quote-selector"
-        target="_blank">TextQuoteSelector</a>
-      that matches the selection <em>unambiguously</em> within the context of
-      the paragraphs.
-    <blockquote id="selectable">
-      <p>Hello, annotated world!
-      <p>To annotate, or not to annotate, that is the question.
-    </blockquote>
-    <p>Here is the selector in JSON format:
-    <pre><code id="parsed"></code></pre>
   </main>
-  <script src="index.js"></script>
+</body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -18,11 +18,14 @@ under the License.
 -->
 <!doctype html>
 <html>
+<head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Apache Annotator (incubating)</title>
-  <link rel="stylesheet" href="https://unpkg.com/marx-css/css/marx.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
   <main>
     <h1>Welcome to Apache Annotator (incubating)</h1>
     <h2>Getting Started</h2>
@@ -31,4 +34,5 @@ under the License.
       <li>Run the <a href="test/index.html">test suite</a>.
     </ul>
   </main>
+</body>
 </html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,52 @@
+body {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
+  line-height: 1.5;
+  margin: 2rem;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 500;
+}
+
+h1 { font-size: 1.4em; }
+h2 { font-size: 1.2em; }
+h3 { font-size: 1.1em; }
+
+header {
+  border-bottom: 1px solid lightgrey;
+  font-size: 0.8em;
+}
+
+nav {
+  margin: 2rem;
+}
+
+main > *:not(.full-width) {
+  max-width: 40rem;
+  margin: 2rem auto;
+}
+
+blockquote {
+  font-style: italic;
+}
+
+li {
+  margin-top: 1em;
+}
+
+mark {
+  background-color: rgba(255, 255, 0, 0.5);
+  outline: 0.1px solid rgba(255, 100, 0, 0.8);
+}
+
+.columns {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.column {
+  min-width: 10rem;
+  width: 10rem;
+  flex-grow: 1;
+  margin: 1rem;
+}

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
   entry: {
     index: [
       './index.html',
+      './style.css',
     ],
     demo: [
       './demo/index.html',


### PR DESCRIPTION
- remove dependencies on remote stylesheets, make a simple sheet instead
- copy some styling&phrasing from the website’s demo
- rephrase some text

Bases on `reorg-webpack` (PR #67), so perhaps best to merge that first (this branch might not even conflict if it was based on master instead, but I did not try)