### PR TITLE
Support empty ranges in highlighter & demo

### DIFF
--- a/web/demo/index.js
+++ b/web/demo/index.js
@@ -120,22 +120,12 @@ async function anchor(selector) {
   info.innerText = JSON.stringify(selector, null, 2);
 }
 
-async function describeSelection() {
-  const selection = document.getSelection();
-  if (selection.type !== 'Range') return;
-
-  const range = selection.getRangeAt(0);
-  if (range.collapsed) return;
-
-  return describeTextQuote(range, source);
-}
-
 async function onSelectionChange() {
-  const selector = await describeSelection();
-  if (selector) {
-    cleanup();
-    anchor(selector);
-  }
+  cleanup();
+  const selection = document.getSelection();
+  const range = selection.getRangeAt(0);
+  const selector = await describeTextQuote(range, source);
+  anchor(selector);
 }
 
 function onSelectorExampleClick(event) {

--- a/web/style.css
+++ b/web/style.css
@@ -56,7 +56,7 @@ li {
 
 mark {
   background-color: rgba(255, 255, 0, 0.5);
-  outline: 0.1px solid rgba(255, 100, 0, 0.8);
+  outline: 1px solid rgba(255, 100, 0, 0.8);
 }
 
 .columns {


### PR DESCRIPTION
When selection contains no characters, we can still show the spot that is selected.

![Screenshot_2020-08-17_14-05-42](https://user-images.githubusercontent.com/4191409/90394451-fb0cf980-e092-11ea-812d-ffe442f6b1ff.png)
