### PR TITLE
Generate less minimal prefixes&suffixes

### DIFF
--- a/packages/dom/src/text-quote/describe.ts
+++ b/packages/dom/src/text-quote/describe.ts
@@ -18,7 +18,10 @@
  * under the License.
  */
 
-import type { TextQuoteSelector } from '@annotator/selector';
+import type {
+  TextQuoteSelector,
+  DescribeTextQuoteOptions,
+} from '@annotator/selector';
 import { describeTextQuote as abstractDescribeTextQuote } from '@annotator/selector';
 import { ownerDocument } from '../owner-document';
 import { TextNodeChunker } from '../text-node-chunker';
@@ -26,6 +29,7 @@ import { TextNodeChunker } from '../text-node-chunker';
 export async function describeTextQuote(
   range: Range,
   maybeScope?: Range,
+  options: DescribeTextQuoteOptions = {},
 ): Promise<TextQuoteSelector> {
   // Default to search in the whole document.
   let scope: Range;
@@ -42,5 +46,6 @@ export async function describeTextQuote(
   return await abstractDescribeTextQuote(
     chunker.rangeToChunkRange(range),
     () => new TextNodeChunker(scope),
+    options,
   );
 }

--- a/packages/dom/test/text-quote/describe-cases.ts
+++ b/packages/dom/test/text-quote/describe-cases.ts
@@ -18,23 +18,179 @@
  * under the License.
  */
 
-import type { TextQuoteSelector } from '@annotator/selector';
+import type {
+  TextQuoteSelector,
+  DescribeTextQuoteOptions,
+} from '@annotator/selector';
 import type { RangeInfo } from '../utils';
 
-export const testCases: {
+export interface DescribeTextQuoteTestCases {
   [name: string]: {
     html: string;
     range: RangeInfo;
+    options: DescribeTextQuoteOptions;
     expected: TextQuoteSelector;
   };
-} = {
-  simple: {
+}
+
+export const testCasesWithoutOptions: DescribeTextQuoteTestCases = {
+  'no context': {
+    html: '<b>lorem ipsum dolor amet yada yada</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 12,
+      endContainerXPath: '//b/text()',
+      endOffset: 22,
+    },
+    options: {},
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'dolor amet',
+      prefix: '',
+      suffix: '',
+    },
+  },
+  'use prefix to complete word': {
+    html: '<b>lorem ipsum dolor amet yada yada</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 14,
+      endContainerXPath: '//b/text()',
+      endOffset: 22,
+    },
+    options: {},
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'lor amet',
+      prefix: 'do',
+      suffix: '',
+    },
+  },
+  'use suffix to complete word': {
     html: '<b>lorem ipsum dolor amet yada yada</b>',
     range: {
       startContainerXPath: '//b/text()',
       startOffset: 12,
       endContainerXPath: '//b/text()',
       endOffset: 20,
+    },
+    options: {},
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'dolor am',
+      prefix: '',
+      suffix: 'et',
+    },
+  },
+  'add context to disambiguate': {
+    html: '<b>To annotate or not to annotate</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 15,
+      endContainerXPath: '//b/text()',
+      endOffset: 18,
+    },
+    options: {},
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'not',
+      prefix: 'or ',
+      suffix: ' to',
+    },
+  },
+  'only prefix for end of text': {
+    html: '<b>To annotate or not to annotate</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 22,
+      endContainerXPath: '//b/text()',
+      endOffset: 30,
+    },
+    options: {},
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'annotate',
+      prefix: 'to ',
+      suffix: '',
+    },
+  },
+  'only suffix for start of text': {
+    html: '<b>annotate or not to annotate, yada yada</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 0,
+      endContainerXPath: '//b/text()',
+      endOffset: 8,
+    },
+    options: {},
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'annotate',
+      prefix: '',
+      suffix: ' or',
+    },
+  },
+  'multiple, overlapping false matches': {
+    html: '<b>a a a a a a a a a a</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 8,
+      endContainerXPath: '//b/text()',
+      endOffset: 13,
+    },
+    options: {},
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'a a a',
+      prefix: 'a a a a ',
+      suffix: ' a a a',
+    },
+  },
+  'empty quote': {
+    html: '<b>To annotate or not to annotate</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 11,
+      endContainerXPath: '//b/text()',
+      endOffset: 11,
+    },
+    options: {},
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: '',
+      prefix: 'To annotate',
+      suffix: ' or',
+    },
+  },
+  'across elements': {
+    html: '<b>To annotate or <i>not</i> to <u>anno</u>tat</b>e',
+    range: {
+      startContainerXPath: '//u/text()',
+      startOffset: 0,
+      endContainerXPath: '//b/text()[3]',
+      endOffset: 2,
+    },
+    options: {},
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'annota',
+      prefix: 'to ',
+      suffix: 'te',
+    },
+  },
+};
+
+export const testCasesWithMinimalContext: DescribeTextQuoteTestCases = {
+  'no context': {
+    html: '<b>lorem ipsum dolor amet yada yada</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 12,
+      endContainerXPath: '//b/text()',
+      endOffset: 20,
+    },
+    options: {
+      minimalContext: true,
     },
     expected: {
       type: 'TextQuoteSelector',
@@ -51,6 +207,9 @@ export const testCases: {
       endContainerXPath: '//b/text()',
       endOffset: 26,
     },
+    options: {
+      minimalContext: true,
+    },
     expected: {
       type: 'TextQuoteSelector',
       exact: 'anno',
@@ -65,6 +224,9 @@ export const testCases: {
       startOffset: 7,
       endContainerXPath: '//b/text()',
       endOffset: 11,
+    },
+    options: {
+      minimalContext: true,
     },
     expected: {
       type: 'TextQuoteSelector',
@@ -81,6 +243,9 @@ export const testCases: {
       endContainerXPath: '//b/text()',
       endOffset: 2,
     },
+    options: {
+      minimalContext: true,
+    },
     expected: {
       type: 'TextQuoteSelector',
       exact: 'to',
@@ -95,6 +260,9 @@ export const testCases: {
       startOffset: 26,
       endContainerXPath: '//b/text()',
       endOffset: 30,
+    },
+    options: {
+      minimalContext: true,
     },
     expected: {
       type: 'TextQuoteSelector',
@@ -111,6 +279,9 @@ export const testCases: {
       endContainerXPath: '//b/text()',
       endOffset: 7,
     },
+    options: {
+      minimalContext: true,
+    },
     expected: {
       type: 'TextQuoteSelector',
       exact: 'aaa',
@@ -126,6 +297,9 @@ export const testCases: {
       endContainerXPath: '//b/text()',
       endOffset: 11,
     },
+    options: {
+      minimalContext: true,
+    },
     expected: {
       type: 'TextQuoteSelector',
       exact: '',
@@ -133,19 +307,117 @@ export const testCases: {
       suffix: ' ',
     },
   },
-  'across elements': {
-    html: '<b>To annotate or <i>not</i> to <u>anno</u>tate</b>',
+};
+
+export const testCasesWithMinimumQuoteLength: DescribeTextQuoteTestCases = {
+  'balance prefix and suffix': {
+    html: '<b>lorem ipsum dolor amet yada yada</b>',
     range: {
-      startContainerXPath: '//u/text()',
-      startOffset: 0,
-      endContainerXPath: '//b/text()[3]',
-      endOffset: 2,
+      startContainerXPath: '//b/text()',
+      startOffset: 12,
+      endContainerXPath: '//b/text()',
+      endOffset: 17,
+    },
+    options: {
+      minimumQuoteLength: 10,
     },
     expected: {
       type: 'TextQuoteSelector',
-      exact: 'annota',
-      prefix: 'to ',
-      suffix: '',
+      exact: 'dolor',
+      prefix: 'ipsum ',
+      suffix: ' amet',
+    },
+  },
+  'use prefix for end of text': {
+    html: '<b>lorem ipsum dolor amet yada yada</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 28,
+      endContainerXPath: '//b/text()',
+      endOffset: 30,
+    },
+    options: {
+      minimumQuoteLength: 10,
+    },
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'ya',
+      prefix: 'amet yada ',
+      suffix: 'da',
+    },
+  },
+  'use suffix for start of text': {
+    html: '<b>lorem ipsum dolor amet yada yada</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 2,
+      endContainerXPath: '//b/text()',
+      endOffset: 3,
+    },
+    options: {
+      minimumQuoteLength: 10,
+    },
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'r',
+      prefix: 'lo',
+      suffix: 'em ipsum',
+    },
+  },
+};
+
+export const testCasesWithMaxWordLength: DescribeTextQuoteTestCases = {
+  'too long prefix': {
+    html: '<b>Surely counterantidisintermediationism is too long to quote.</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 28,
+      endContainerXPath: '//b/text()',
+      endOffset: 31,
+    },
+    options: {
+      maxWordLength: 10,
+    },
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'dia',
+      prefix: 'disinterme',
+      suffix: 'tionism',
+    },
+  },
+  'too long suffix': {
+    html: '<b>Surely counterantidisintermediationism is too long to quote.</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 14,
+      endContainerXPath: '//b/text()',
+      endOffset: 18,
+    },
+    options: {
+      maxWordLength: 10,
+    },
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'anti',
+      prefix: 'counter',
+      suffix: 'disinterme',
+    },
+  },
+  'default should be 50': {
+    html:
+      '<b>The chromosome is ACATATTACGTTAGATATGACACCCATATAGTTATTTATAAGATGGGACAGATATTAGTTTAAAAA</b>',
+    range: {
+      startContainerXPath: '//b/text()',
+      startOffset: 18,
+      endContainerXPath: '//b/text()',
+      endOffset: 27,
+    },
+    options: {},
+    expected: {
+      type: 'TextQuoteSelector',
+      exact: 'ACATATTAC',
+      prefix: '',
+      suffix: 'GTTAGATATGACACCCATATAGTTATTTATAAGATGGGACAGATATTAGT',
     },
   },
 };

--- a/packages/dom/test/text-quote/describe.test.ts
+++ b/packages/dom/test/text-quote/describe.test.ts
@@ -21,29 +21,65 @@
 import { assert } from 'chai';
 import { describeTextQuote } from '../../src/text-quote/describe';
 import { hydrateRange, evaluateXPath } from '../utils';
-import { testCases } from './describe-cases';
+import type { DescribeTextQuoteTestCases } from './describe-cases';
+import {
+  testCasesWithMinimumQuoteLength,
+  testCasesWithMaxWordLength,
+  testCasesWithMinimalContext,
+  testCasesWithoutOptions,
+} from './describe-cases';
 import { testCases as testMatchCases } from './match-cases';
 
 const domParser = new window.DOMParser();
 
-describe('describeTextQuote', () => {
-  for (const [name, { html, range, expected }] of Object.entries(testCases)) {
+function runTestCases(testCases: DescribeTextQuoteTestCases) {
+  for (const [name, { html, range, expected, options }] of Object.entries(
+    testCases,
+  )) {
     it(`works for case: ${name}`, async () => {
       const doc = domParser.parseFromString(html, 'text/html');
       const scope = doc.createRange();
       scope.selectNodeContents(doc);
-      const result = await describeTextQuote(hydrateRange(range, doc), scope);
+      const result = await describeTextQuote(
+        hydrateRange(range, doc),
+        scope,
+        options,
+      );
       assert.deepEqual(result, expected);
     });
   }
+}
+
+describe('describeTextQuote', () => {
+  describe('without options', () => {
+    runTestCases(testCasesWithoutOptions);
+  });
+
+  describe('with minimal context', () => {
+    runTestCases(testCasesWithMinimalContext);
+  });
+
+  describe('with minimum quote length', () => {
+    runTestCases(testCasesWithMinimumQuoteLength);
+  });
+
+  describe('with max word length', () => {
+    runTestCases(testCasesWithMaxWordLength);
+  });
 
   it('works with custom scope', async () => {
-    const { html, range } = testCases['minimal prefix'];
+    const { html, range, options } = testCasesWithMinimalContext[
+      'minimal prefix'
+    ];
     const doc = domParser.parseFromString(html, 'text/html');
     const scope = doc.createRange();
     scope.setStart(evaluateXPath(doc, '//b/text()'), 15);
     scope.setEnd(evaluateXPath(doc, '//b/text()'), 30); // "not to annotate"
-    const result = await describeTextQuote(hydrateRange(range, doc), scope);
+    const result = await describeTextQuote(
+      hydrateRange(range, doc),
+      scope,
+      options,
+    );
     assert.deepEqual(result, {
       type: 'TextQuoteSelector',
       exact: 'anno',
@@ -53,12 +89,16 @@ describe('describeTextQuote', () => {
   });
 
   it('strips part of the range outside the scope', async () => {
-    const { html, range } = testCases['simple'];
+    const { html, range, options } = testCasesWithMinimalContext['no context'];
     const doc = domParser.parseFromString(html, 'text/html');
     const scope = doc.createRange();
     scope.setStart(evaluateXPath(doc, '//b/text()'), 6);
     scope.setEnd(evaluateXPath(doc, '//b/text()'), 17); // "ipsum dolor"
-    const result = await describeTextQuote(hydrateRange(range, doc), scope);
+    const result = await describeTextQuote(
+      hydrateRange(range, doc),
+      scope,
+      options,
+    );
     assert.deepEqual(result, {
       type: 'TextQuoteSelector',
       exact: 'dolor',
@@ -68,11 +108,14 @@ describe('describeTextQuote', () => {
   });
 
   it('works if the range equals the scope', async () => {
-    const { html, range, expected } = testCases['simple'];
+    const { html, range, expected, options } = testCasesWithMinimalContext[
+      'no context'
+    ];
     const doc = domParser.parseFromString(html, 'text/html');
     const result = await describeTextQuote(
       hydrateRange(range, doc),
       hydrateRange(range, doc),
+      options,
     );
     assert.deepEqual(result, expected);
   });

--- a/web/demo/index.js
+++ b/web/demo/index.js
@@ -138,7 +138,7 @@ async function onSelectionChange() {
     const selector =
       describeMode === 'TextPosition'
         ? await describeTextPosition(range, scope)
-        : await describeTextQuote(range, scope);
+        : await describeTextQuote(range, scope, { minimumQuoteLength: 10 });
     await anchor(selector);
   }
 }


### PR DESCRIPTION
A TextQuoteSelector can add as much prefix and suffix as desired. Until now, we only added prefix and suffix as much as was strictly necessary to disambiguate the target from other occurrences of the exact same text in the same document. When an annotation should still anchor on a modified version of the document, it can be helpful to add a little more context, in order to be robust against the ambiguity that would result if after such a modification the quoted text appears in more places than before.

Also, it seems neat to have the prefix and suffix contain whole words instead of stopping halfway inside a word. This makes it pleasant to read when user interfaces expose the prefix&suffix. Also it makes the implementation closer to being compatible with the WICG TextFragments spec (see #60).

This PR thus adds two ways to generate less minimal prefixes&suffixes:

 1. Round them up to the next whitespace.
 2. Optionally add prefix&suffix around a short quote even if it is not
     ambiguous.

I made rounding up to whitespace the default behaviour, while the previous behaviour can still be obtained using the option `minimalContext`. For the context around short quotes I would not know what would be a good default (might depend on use case and document length?); so I left it at 0 for now, i.e. the feature is turned off by default.

This PR also refactors the implementation a bit, reusing the seekers instead of creating new ones on every match.

To pass options, I added an `options` object as the last function parameter. I thought we might want to move the `scope` parameter into this option object too, but `scope` is specific to the DOM implementation, so I’m not sure if that is desirable.

I added options for anything that would otherwise feel like we’re hardcoding a ‘magic number’, but of course quite some choices on how exactly the algorithm works are hardcoded opinions too. I doubted between a few variations, but thought this the most straightforward with I hope generally sensible results. To be seen in practice, I guess.

I added basic tests for each of the new behaviours. Currently these tests are still in the dom package, but should be refactored and moved into the selector package as the actual algorithms being tested reside there.