### PR TITLE
Add a Travis CI step to publish a dev release in npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,13 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
   - export PATH="$HOME/.yarn/bin:$PATH"
 
+deploy:
+  - provider: script
+    script: git checkout master && npx lerna publish --preid dev --dist-tag dev --canary --yes
+    skip_cleanup: true
+    on:
+      branch: master
+
 branches:
   only:
     - master


### PR DESCRIPTION
Hello there,

This PR configures github to publish an artifact to npm with the `dev` [tag](https://docs.npmjs.com/adding-dist-tags-to-packages#publishing-a-package-with-a-dist-tag) satisfying https://github.com/apache/incubator-annotator/issues/92. I _think_ publishing with a dist tag will be sufficient to get the new package out there. However I might be mistaken and we will have to publish a new version as well. In the latter case, we could publish a [prerelease version](https://docs.npmjs.com/cli/v7/using-npm/semver#prerelease-identifiers).

One other thing I wanted to check: currently this PR will attempt to publish to any commit to master within _this_ (the apache/incubator-annotator) repo. It doesn't check the result of the Travis CI tests. After some cursor googling there didn't seem to be a way to ensure the tests passed and only then publish the artifact. It didn't seem like a GH action job could depend on a check outside itself. Again, I may be wrong on this. If I'm not, would the project be willing to ditch Travis and run the tests via Github Actions solely?