### PR TITLE
Move from @annotator to @apache-annotator scope

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,7 +65,7 @@ module.exports = {
     ],
   },
   settings: {
-    'import/internal-regex': '^@annotator/',
+    'import/internal-regex': '^@apache-annotator/',
     'import/resolver': {
       'babel-module': babelModuleResolver.options,
     },

--- a/README.md
+++ b/README.md
@@ -11,26 +11,27 @@ compiled and distributed in CommonJS and ECMAScript Module formats.
 
 The project is made up of multiple packages. Install the `apache-annotator`
 package, which includes all sub-packages, or install individual packages from
-the `@annotator` scope.
+the `@apache-annotator` scope.
 
-Import packages from either `apache-annotator/package` or `@annotator/package`.
+Import packages from either `apache-annotator/package` or
+`@apache-annotator/package`.
 
 Currently, the following sub-packages are part of the project:
 
-### `@annotator/dom`
+### `@apache-annotator/dom`
 
 This package contains functions for creating and resolving Web Annotation
 Selectors in DOM environments.
 
-### `@annotator/selector`
+### `@apache-annotator/selector`
 
 This package contains generic utilities for composing functions that create
 and resolve Web Annotation Selectors.
 
 ## Getting Involved
 
-* Join the [mailing list]. Send an email to dev-subscribe@annotator.apache.org
-  to subscribe.
+* Join the [mailing list]. Send an email to
+  dev-subscribe@apache-annotator.apache.org to subscribe.
 * Browse the [issue tracker] and file new issues if you encounter problems.
 * Read or contribute to the [wiki].
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -56,7 +56,7 @@ module.exports = (api) => {
     alias: {
       ...(DEV || TEST
         ? {
-            '^@annotator/([^/]+)$': path.join(
+            '^@apache-annotator/([^/]+)$': path.join(
               __dirname,
               'packages/\\1/src/index.ts',
             ),

--- a/packages/apache-annotator/package.json
+++ b/packages/apache-annotator/package.json
@@ -28,8 +28,8 @@
   "module": "./lib/index.mjs",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@annotator/dom": "^0.1.0",
-    "@annotator/selector": "^0.1.0",
+    "@apache-annotator/dom": "^0.1.0",
+    "@apache-annotator/selector": "^0.1.0",
     "@babel/runtime-corejs3": "^7.8.7"
   },
   "engines": {

--- a/packages/apache-annotator/src/dom/index.ts
+++ b/packages/apache-annotator/src/dom/index.ts
@@ -1,1 +1,1 @@
-export * from '@annotator/dom';
+export * from '@apache-annotator/dom';

--- a/packages/apache-annotator/src/index.ts
+++ b/packages/apache-annotator/src/index.ts
@@ -1,2 +1,2 @@
-export * as dom from '@annotator/dom';
-export * as selector from '@annotator/selector';
+export * as dom from '@apache-annotator/dom';
+export * as selector from '@apache-annotator/selector';

--- a/packages/apache-annotator/src/selector/index.ts
+++ b/packages/apache-annotator/src/selector/index.ts
@@ -1,1 +1,1 @@
-export * from '@annotator/selector';
+export * from '@apache-annotator/selector';

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@annotator/dom",
+  "name": "@apache-annotator/dom",
   "version": "0.1.0",
   "description": "Utilities for annotation of the Document Object Model.",
   "homepage": "https://annotator.apache.org",
@@ -21,7 +21,7 @@
     "@babel/runtime-corejs3": "^7.8.7"
   },
   "devDependencies": {
-    "@annotator/selector": "^0.1.0"
+    "@apache-annotator/selector": "^0.1.0"
   },
   "engines": {
     "node": "^10 || ^11 || ^12 || >=13.7"

--- a/packages/dom/src/css.ts
+++ b/packages/dom/src/css.ts
@@ -18,7 +18,7 @@
  * under the License.
  */
 
-import type { CssSelector, Matcher } from '@annotator/selector';
+import type { CssSelector, Matcher } from '@apache-annotator/selector';
 import { ownerDocument } from './owner-document';
 
 export function createCssSelectorMatcher(

--- a/packages/dom/src/range/match.ts
+++ b/packages/dom/src/range/match.ts
@@ -18,7 +18,11 @@
  * under the License.
  */
 
-import type { Matcher, RangeSelector, Selector } from '@annotator/selector';
+import type {
+  Matcher,
+  RangeSelector,
+  Selector,
+} from '@apache-annotator/selector';
 import { ownerDocument } from '../owner-document';
 import { cartesian } from './cartesian';
 

--- a/packages/dom/src/text-node-chunker.ts
+++ b/packages/dom/src/text-node-chunker.ts
@@ -18,7 +18,7 @@
  * under the License.
  */
 
-import type { Chunk, Chunker, ChunkRange } from '@annotator/selector';
+import type { Chunk, Chunker, ChunkRange } from '@apache-annotator/selector';
 import { normalizeRange } from './normalize-range';
 import { ownerDocument } from './owner-document';
 

--- a/packages/dom/src/text-position/describe.ts
+++ b/packages/dom/src/text-position/describe.ts
@@ -18,8 +18,8 @@
  * under the License.
  */
 
-import type { TextPositionSelector } from '@annotator/selector';
-import { describeTextPosition as abstractDescribeTextPosition } from '@annotator/selector';
+import type { TextPositionSelector } from '@apache-annotator/selector';
+import { describeTextPosition as abstractDescribeTextPosition } from '@apache-annotator/selector';
 import { ownerDocument } from '../owner-document';
 import { TextNodeChunker } from '../text-node-chunker';
 

--- a/packages/dom/src/text-position/match.ts
+++ b/packages/dom/src/text-position/match.ts
@@ -18,8 +18,8 @@
  * under the License.
  */
 
-import type { Matcher, TextPositionSelector } from '@annotator/selector';
-import { textPositionSelectorMatcher as abstractTextPositionSelectorMatcher } from '@annotator/selector';
+import type { Matcher, TextPositionSelector } from '@apache-annotator/selector';
+import { textPositionSelectorMatcher as abstractTextPositionSelectorMatcher } from '@apache-annotator/selector';
 import { TextNodeChunker } from '../text-node-chunker';
 
 export function createTextPositionSelectorMatcher(

--- a/packages/dom/src/text-quote/describe.ts
+++ b/packages/dom/src/text-quote/describe.ts
@@ -21,8 +21,8 @@
 import type {
   TextQuoteSelector,
   DescribeTextQuoteOptions,
-} from '@annotator/selector';
-import { describeTextQuote as abstractDescribeTextQuote } from '@annotator/selector';
+} from '@apache-annotator/selector';
+import { describeTextQuote as abstractDescribeTextQuote } from '@apache-annotator/selector';
 import { ownerDocument } from '../owner-document';
 import { TextNodeChunker } from '../text-node-chunker';
 

--- a/packages/dom/src/text-quote/match.ts
+++ b/packages/dom/src/text-quote/match.ts
@@ -18,8 +18,8 @@
  * under the License.
  */
 
-import type { Matcher, TextQuoteSelector } from '@annotator/selector';
-import { textQuoteSelectorMatcher as abstractTextQuoteSelectorMatcher } from '@annotator/selector';
+import type { Matcher, TextQuoteSelector } from '@apache-annotator/selector';
+import { textQuoteSelectorMatcher as abstractTextQuoteSelectorMatcher } from '@apache-annotator/selector';
 import { TextNodeChunker, EmptyScopeError } from '../text-node-chunker';
 
 export function createTextQuoteSelectorMatcher(

--- a/packages/dom/test/text-position/match-cases.ts
+++ b/packages/dom/test/text-position/match-cases.ts
@@ -18,7 +18,7 @@
  * under the License.
  */
 
-import type { TextPositionSelector } from '@annotator/selector';
+import type { TextPositionSelector } from '@apache-annotator/selector';
 import type { RangeInfo } from '../utils';
 
 export const testCases: {

--- a/packages/dom/test/text-position/match.test.ts
+++ b/packages/dom/test/text-position/match.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { assert } from 'chai';
-import type { TextPositionSelector } from '@annotator/selector';
+import type { TextPositionSelector } from '@apache-annotator/selector';
 import { createTextPositionSelectorMatcher } from '../../src/text-position/match';
 import { evaluateXPath } from '../utils';
 import type { RangeInfo } from '../utils';

--- a/packages/dom/test/text-quote/describe-cases.ts
+++ b/packages/dom/test/text-quote/describe-cases.ts
@@ -21,7 +21,7 @@
 import type {
   TextQuoteSelector,
   DescribeTextQuoteOptions,
-} from '@annotator/selector';
+} from '@apache-annotator/selector';
 import type { RangeInfo } from '../utils';
 
 export interface DescribeTextQuoteTestCases {

--- a/packages/dom/test/text-quote/match-cases.ts
+++ b/packages/dom/test/text-quote/match-cases.ts
@@ -18,7 +18,7 @@
  * under the License.
  */
 
-import type { TextQuoteSelector } from '@annotator/selector';
+import type { TextQuoteSelector } from '@apache-annotator/selector';
 import type { RangeInfo } from '../utils';
 
 export const testCases: {

--- a/packages/dom/test/text-quote/match.test.ts
+++ b/packages/dom/test/text-quote/match.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { assert } from 'chai';
-import type { TextQuoteSelector } from '@annotator/selector';
+import type { TextQuoteSelector } from '@apache-annotator/selector';
 import { createTextQuoteSelectorMatcher } from '../../src/text-quote/match';
 import { evaluateXPath } from '../utils';
 import type { RangeInfo } from '../utils';

--- a/packages/selector/package.json
+++ b/packages/selector/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@annotator/selector",
+  "name": "@apache-annotator/selector",
   "version": "0.1.0",
   "description": "Web Annotation selector for engine.",
   "homepage": "https://annotator.apache.org",

--- a/web/demo/index.js
+++ b/web/demo/index.js
@@ -27,8 +27,8 @@ import {
   createTextPositionSelectorMatcher,
   describeTextPosition,
   highlightRange,
-} from '@annotator/dom';
-import { makeRefinable } from '@annotator/selector';
+} from '@apache-annotator/dom';
+import { makeRefinable } from '@apache-annotator/selector';
 
 const EXAMPLE_SELECTORS = [
   {


### PR DESCRIPTION
Change the package scope from @annotator to @apache-annotator to make
branding clearer, provide symmetry between the unscoped meta-package and
the separate packages, and to distinguish the packages more clearly from
the old Annotator.js project.