### PR TITLE
Improve performance for large documents with many annotations

### DIFF
--- a/packages/dom/src/text-node-chunker.ts
+++ b/packages/dom/src/text-node-chunker.ts
@@ -38,15 +38,6 @@ export class EmptyScopeError extends TypeError {
   }
 }
 
-export class OutOfScopeError extends TypeError {
-  constructor(message?: string) {
-    super(
-      message ||
-        'Cannot convert node to chunk, as it falls outside of chunker’s scope.',
-    );
-  }
-}
-
 export class TextNodeChunker implements Chunker<PartialTextNode> {
   private scope: Range;
   private iter: NodeIterator;
@@ -61,8 +52,6 @@ export class TextNodeChunker implements Chunker<PartialTextNode> {
   }
 
   nodeToChunk(node: Text): PartialTextNode {
-    if (!this.scope.intersectsNode(node)) throw new OutOfScopeError();
-
     const startOffset =
       node === this.scope.startContainer ? this.scope.startOffset : 0;
     const endOffset =


### PR DESCRIPTION
Hello and thank you for this wonderful project. It's provided some excellent shoulders to stand on.

### Context
I'm extracting footnotes embedded in markdown and converting them annotations. Some of these markdown files have over 500k characters in them and have over 100 footnotes. After a quite circuitous route, I'm using mdast/hast/remark to convert the markdown into html and then loading the html into a jsdom Document.

### The Problem
I found that extracting footnotes for some of the larger files was taking 7 - 10 minutes to process. Running a profiler, it looked like 70% of the time was spent determining if the node intersected the document/scope.
![image](https://user-images.githubusercontent.com/36475/187796176-82638def-398a-405a-b78c-6a0177f2f04b.png)

That [call is happening](https://github.com/apache/incubator-annotator/blob/main/packages/dom/src/text-node-chunker.ts#L64) when the node is being converted to a chunk, which happens many times, per annotation. It is also only being used to ensure that the node is apart of the document (as far as I can tell).

### The Solution
This PR removes that check. It improved the performance on my machine by 75% for the large files.

Behaviorally I _think_ it is the same. The two things which invoke `nodeToChunk` appear to be already checking if those nodes are a part of the scope.